### PR TITLE
Update tag logic to use both keys and values

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -34,7 +34,7 @@ const evaluateNodes = (nodes, targetLat, targetLon) => {
             if (node.children.length > 1) {
                 query += "(";
                 query += evaluateNodes(node.children, targetLat, targetLon);
-                query += ")";
+                query += ");";
             } else {
                 query += evaluateNodes(node.children, targetLat, targetLon);
             }
@@ -50,7 +50,7 @@ const evaluateNodes = (nodes, targetLat, targetLon) => {
 const buildOverpassQuery = (anchorData, treeData) => {
     let query = "[out:json];";
     query += evaluateNodes(treeData.data, anchorData.lat, anchorData.lon);
-    query += ";out count;";
+    query += "out count;";
     console.log("overpass query", query);
     return query;
 }

--- a/background.ts
+++ b/background.ts
@@ -31,6 +31,7 @@ const evaluateNodes = (nodes, targetLat, targetLon) => {
     let query = "";
     nodes.forEach((node) => {
         if (node.type === "ConditionalNode") {
+            // TODO: and vs or statements
             if (node.children.length > 1) {
                 query += "(";
                 query += evaluateNodes(node.children, targetLat, targetLon);
@@ -39,7 +40,6 @@ const evaluateNodes = (nodes, targetLat, targetLon) => {
                 query += evaluateNodes(node.children, targetLat, targetLon);
             }
         } else if (node.type === "ValueNode") {
-            // TODO: elements have 2 tags, not just 1, need to map "name" to user input rather than hardcoding
             // Tags are searched case insensitive via the "~"" and ",i" parameters
             query += `nwr["${node.tagKey}"~"${node.tagValue}",i](around:${node.value}, ${targetLat}, ${targetLon});`
         }

--- a/background.ts
+++ b/background.ts
@@ -41,7 +41,7 @@ const evaluateNodes = (nodes, targetLat, targetLon) => {
         } else if (node.type === "ValueNode") {
             // TODO: elements have 2 tags, not just 1, need to map "name" to user input rather than hardcoding
             // Tags are searched case insensitive via the "~"" and ",i" parameters
-            query += `nwr["leisure"~"${node.tag}",i](around:${node.value}, ${targetLat}, ${targetLon});`
+            query += `nwr["${node.tagKey}"~"${node.tagValue}",i](around:${node.value}, ${targetLat}, ${targetLon});`
         }
     });
     return query;

--- a/popup.tsx
+++ b/popup.tsx
@@ -27,16 +27,16 @@ const handleLoadPersona = (persona, setTreeData) => {
                 {
                   "id": 1689593778325,
                   "type": "ValueNode",
-                  "tagKey": "leisure",
-                  "tagValue": "elementary_school_district",
+                  "tagKey": "school",
+                  "tagValue": "elementary",
                   "operator": "lessThan",
                   "value": "1000"
                 },
                 {
                   "id": 1689593779351,
                   "type": "ValueNode",
-                  "tagKey": "leisure",
-                  "tagValue": "Grocery",
+                  "tagKey": "shop",
+                  "tagValue": "grocery",
                   "operator": "lessThan",
                   "value": "5000"
                 },
@@ -44,8 +44,8 @@ const handleLoadPersona = (persona, setTreeData) => {
                   "id": 1689900486428,
                   "type": "ValueNode",
                   "tagKey": "leisure",
-                  "tagValue": "PARK",
-                  "operator": "lessThanessThan",
+                  "tagValue": "park",
+                  "operator": "lessThan",
                   "value": "1000"
                 }
               ]
@@ -66,16 +66,16 @@ const handleLoadPersona = (persona, setTreeData) => {
                 {
                   "id": 1689593778325,
                   "type": "ValueNode",
-                  "tagKey": "leisure",
-                  "tagValue": "Gym",
+                  "tagKey": "amenity",
+                  "tagValue": "gym",
                   "operator": "lessThan",
                   "value": "1000"
                 },
                 {
                   "id": 1689593779351,
                   "type": "ValueNode",
-                  "tagKey": "leisure",
-                  "tagValue": "football",
+                  "tagKey": "landuse",
+                  "tagValue": "sport",
                   "operator": "lessThan",
                   "value": "5000"
                 },
@@ -83,7 +83,7 @@ const handleLoadPersona = (persona, setTreeData) => {
                   "id": 1689900486428,
                   "type": "ValueNode",
                   "tagKey": "leisure",
-                  "tagValue": "PARK",
+                  "tagValue": "park",
                   "operator": "lessThan",
                   "value": "1000"
                 },
@@ -95,8 +95,16 @@ const handleLoadPersona = (persona, setTreeData) => {
                     {
                       "id": 1689901926343,
                       "type": "ValueNode",
-                      "tagKey": "leisure",
+                      "tagKey": "name",
                       "tagValue": "Whole Foods",
+                      "operator": "lessThan",
+                      "value": "4000"
+                    },
+                    {
+                      "id": 1689901926344,
+                      "type": "ValueNode",
+                      "tagKey": "brand",
+                      "tagValue": "Trader Joe's",
                       "operator": "lessThan",
                       "value": "6000"
                     }

--- a/popup.tsx
+++ b/popup.tsx
@@ -27,22 +27,25 @@ const handleLoadPersona = (persona, setTreeData) => {
                 {
                   "id": 1689593778325,
                   "type": "ValueNode",
-                  "tag": "elementary_school_district",
+                  "tagKey": "leisure",
+                  "tagValue": "elementary_school_district",
                   "operator": "lessThan",
                   "value": "1000"
                 },
                 {
                   "id": 1689593779351,
                   "type": "ValueNode",
-                  "tag": "Grocery",
+                  "tagKey": "leisure",
+                  "tagValue": "Grocery",
                   "operator": "lessThan",
                   "value": "5000"
                 },
                 {
                   "id": 1689900486428,
                   "type": "ValueNode",
-                  "tag": "PARK",
-                  "operator": "lessThan",
+                  "tagKey": "leisure",
+                  "tagValue": "PARK",
+                  "operator": "lessThanessThan",
                   "value": "1000"
                 }
               ]
@@ -63,21 +66,24 @@ const handleLoadPersona = (persona, setTreeData) => {
                 {
                   "id": 1689593778325,
                   "type": "ValueNode",
-                  "tag": "Gym",
+                  "tagKey": "leisure",
+                  "tagValue": "Gym",
                   "operator": "lessThan",
                   "value": "1000"
                 },
                 {
                   "id": 1689593779351,
                   "type": "ValueNode",
-                  "tag": "football",
+                  "tagKey": "leisure",
+                  "tagValue": "football",
                   "operator": "lessThan",
                   "value": "5000"
                 },
                 {
                   "id": 1689900486428,
                   "type": "ValueNode",
-                  "tag": "PARK",
+                  "tagKey": "leisure",
+                  "tagValue": "PARK",
                   "operator": "lessThan",
                   "value": "1000"
                 },
@@ -89,16 +95,10 @@ const handleLoadPersona = (persona, setTreeData) => {
                     {
                       "id": 1689901926343,
                       "type": "ValueNode",
-                      "tag": "Whole Foods",
+                      "tagKey": "leisure",
+                      "tagValue": "Whole Foods",
                       "operator": "lessThan",
                       "value": "6000"
-                    },
-                    {
-                      "id": 1689901951617,
-                      "type": "ValueNode",
-                      "tag": "newTag",
-                      "operator": "equals",
-                      "value": "5000"
                     }
                   ]
                 }
@@ -118,6 +118,7 @@ const handleLoadPersona = (persona, setTreeData) => {
 }
 
 function IndexPopup() {
+  // TODO: send message to background when tree is modified to re-evaluate & propogate to content
   const [treeData, setTreeData] = useStorage(STORAGE_KEY, {
     lastModified: Date.now(),
     data: [
@@ -177,6 +178,7 @@ function IndexPopup() {
   const updateNodeField = (nodes, nodeId, field, newValue) => {
     return nodes.map((node) => {
       if (node.id === nodeId) {
+        // TODO: Handle objects as fields
         return { ...node, [field]: newValue };
       } else if (node.children && node.children.length > 0) {
         return { ...node, children: updateNodeField(node.children, nodeId, field, newValue) };
@@ -203,7 +205,8 @@ function IndexPopup() {
         const newNode = {
           id: Date.now(),
           type: nodeType,
-          tag: 'newTag',
+          tagKey: 'newTagKey',
+          tagValue: 'newTagValue',
           operator: 'equals',
           value: 'newValue',
         };
@@ -230,7 +233,8 @@ function IndexPopup() {
             {
               id: Date.now() + 1,
               type: 'ValueNode',
-              tag: 'newTag',
+              tagKey: 'newTagKey',
+              tagValue: 'newTagValue',
               operator: 'equals',
               value: 'newValue',
             },
@@ -251,7 +255,7 @@ function IndexPopup() {
   return (
     <div
       style={{
-        width: 600,
+        width: 800,
       }}>
       <h1>Settings</h1>
       <span>Last modified: {treeData.lastModified}</span>

--- a/tree.tsx
+++ b/tree.tsx
@@ -30,6 +30,22 @@ const debounce = (func, delay) => {
   };
 };
 
+const filterTagValues = async (inputValue: string, callback: (options: Option[]) => void) => {
+    try {
+      // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
+      const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
+      const response = await axios.get(url);
+      const matchingOptions = response.data.data.map((tag) => ({
+        value: tag.key,
+        label: tag.key,
+      }));
+      callback(matchingOptions);
+    } catch (error) {
+      console.log('Error fetching tags:', error);
+      callback([]);
+    }
+  };
+
 // TODO: Convert tagKey and tagValue to common object with explicit fields. Requires update to node change tracking.
 const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddConditionalNode }) => {
   const renderTreeNodes = (nodes) => {
@@ -63,22 +79,6 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
         )}
       </li>
     );
-  };
-
-  const filterTagValues = async (inputValue: string, callback: (options: Option[]) => void) => {
-    try {
-      // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
-      const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
-      const response = await axios.get(url);
-      const matchingOptions = response.data.data.map((tag) => ({
-        value: tag.key,
-        label: tag.key,
-      }));
-      callback(matchingOptions);
-    } catch (error) {
-      console.log('Error fetching tags:', error);
-      callback([]);
-    }
   };
 
   const renderValueNode = (node) => {

--- a/tree.tsx
+++ b/tree.tsx
@@ -48,14 +48,25 @@ const filterTagKeys = async (inputValue: string, callback: (options: Option[]) =
 
 const filterTagValues = async (inputValue: string, callback: (options: Option[]) => void) => {
   try {
-    // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
-    const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
+    // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_search_by_value";
+    const params = new URLSearchParams({
+      query: inputValue,
+      page: "1",
+      rp: "25",
+      sortname: "count_all",
+      sortorder: "desc",
+    });
+    const url = `https://taginfo.openstreetmap.org/api/4/search/by_value?${params.toString()}`;
     const response = await axios.get(url);
-    const matchingOptions = response.data.data.map((tag) => ({
-      value: tag.key,
-      label: tag.key,
-    }));
-    callback(matchingOptions);
+    const matchingOptions = response.data.data.map(tag => tag.value);
+    const uniqueMatches: Option[] = Array.from(new Set<string>(matchingOptions))
+      .map((tagValue) => (
+        {
+          value: tagValue,
+          label: tagValue,
+        }
+      ));
+    callback(uniqueMatches);
   } catch (error) {
     console.log('Error fetching tags:', error);
     callback([]);

--- a/tree.tsx
+++ b/tree.tsx
@@ -81,17 +81,6 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
     }
   };
 
-  const debouncedFilterTags = debounce(filterTagValues, 500);
-
-  const callbackOptions = (inputValue: string, callback: (options: Option[]) => void) => {
-    try {
-      debouncedFilterTags(inputValue, callback);
-    } catch (error) {
-      console.log('Error fetching tags:', error);
-      callback([]);
-    }
-  };
-
   const renderValueNode = (node) => {
     return (
       <li key={node.id}>
@@ -107,7 +96,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
             cacheOptions
             defaultOptions
             value={{value: node.tagKey, label: node.tagKey}}
-            loadOptions={callbackOptions}
+            loadOptions={debounce(filterTagValues, 500)}
             onChange={(e: any) => onNodeFieldChange(node.id, 'tagKey', e.value)}
             styles={{
               control: (baseStyles, state) => ({
@@ -121,7 +110,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
             cacheOptions
             defaultOptions
             value={{value: node.tagValue, label: node.tagValue}}
-            loadOptions={callbackOptions}
+            loadOptions={debounce(filterTagValues, 500)}
             onChange={(e: any) => onNodeFieldChange(node.id, 'tagValue', e.value)}
             styles={{
               control: (baseStyles, state) => ({

--- a/tree.tsx
+++ b/tree.tsx
@@ -30,6 +30,7 @@ const debounce = (func, delay) => {
   };
 };
 
+// TODO: Convert tagKey and tagValue to common object with explicit fields. Requires update to node change tracking.
 const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddConditionalNode }) => {
   const renderTreeNodes = (nodes) => {
     return nodes.map((node) => {
@@ -64,7 +65,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
     );
   };
 
-  const filterTags = async (inputValue: string, callback: (options: Option[]) => void) => {
+  const filterTagValues = async (inputValue: string, callback: (options: Option[]) => void) => {
     try {
       // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
       const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
@@ -80,7 +81,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
     }
   };
 
-  const debouncedFilterTags = debounce(filterTags, 500);
+  const debouncedFilterTags = debounce(filterTagValues, 500);
 
   const callbackOptions = (inputValue: string, callback: (options: Option[]) => void) => {
     try {
@@ -95,12 +96,19 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
     return (
       <li key={node.id}>
         <div style={{display: 'flex'}}>
+          {/* 
+          TODO:
+          Add additional dropdown for tag key in addition to the tag value.
+          Populate dropdown with most common combination by default, but allow user to modify.
+          1) Search by tag value, e.g. grocery, sorting by count_all desc.
+          2) Populate tag key options with top 10-20 most common tag keys associated to tag value
+          */}
           <AsyncCreatableSelect
             cacheOptions
             defaultOptions
-            value={{value: node.tag, label: node.tag}}
+            value={{value: node.tagValue, label: node.tagValue}}
             loadOptions={callbackOptions}
-            onChange={(e: any) => onNodeFieldChange(node.id, 'tag', e.value)}
+            onChange={(e: any) => onNodeFieldChange(node.id, 'tagValue', e.value)}
             styles={{
               control: (baseStyles, state) => ({
                 ...baseStyles,

--- a/tree.tsx
+++ b/tree.tsx
@@ -30,21 +30,37 @@ const debounce = (func, delay) => {
   };
 };
 
+const filterTagKeys = async (inputValue: string, callback: (options: Option[]) => void) => {
+  try {
+    // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
+    const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
+    const response = await axios.get(url);
+    const matchingOptions = response.data.data.map((tag) => ({
+      value: tag.key,
+      label: tag.key,
+    }));
+    callback(matchingOptions);
+  } catch (error) {
+    console.log('Error fetching tags:', error);
+    callback([]);
+  }
+};
+
 const filterTagValues = async (inputValue: string, callback: (options: Option[]) => void) => {
-    try {
-      // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
-      const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
-      const response = await axios.get(url);
-      const matchingOptions = response.data.data.map((tag) => ({
-        value: tag.key,
-        label: tag.key,
-      }));
-      callback(matchingOptions);
-    } catch (error) {
-      console.log('Error fetching tags:', error);
-      callback([]);
-    }
-  };
+  try {
+    // Docs: "https://taginfo.openstreetmap.org/taginfo/apidoc#api_4_keys_all";
+    const url = `https://taginfo.openstreetmap.org/api/4/keys/all?page=1&rp=20&sortame=key&sortorder=asc&query=${inputValue}`;
+    const response = await axios.get(url);
+    const matchingOptions = response.data.data.map((tag) => ({
+      value: tag.key,
+      label: tag.key,
+    }));
+    callback(matchingOptions);
+  } catch (error) {
+    console.log('Error fetching tags:', error);
+    callback([]);
+  }
+};
 
 // TODO: Convert tagKey and tagValue to common object with explicit fields. Requires update to node change tracking.
 const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddConditionalNode }) => {
@@ -96,7 +112,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
             cacheOptions
             defaultOptions
             value={{value: node.tagKey, label: node.tagKey}}
-            loadOptions={debounce(filterTagValues, 500)}
+            loadOptions={debounce(filterTagKeys, 500)}
             onChange={(e: any) => onNodeFieldChange(node.id, 'tagKey', e.value)}
             styles={{
               control: (baseStyles, state) => ({

--- a/tree.tsx
+++ b/tree.tsx
@@ -106,6 +106,20 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
           <AsyncCreatableSelect
             cacheOptions
             defaultOptions
+            value={{value: node.tagKey, label: node.tagKey}}
+            loadOptions={callbackOptions}
+            onChange={(e: any) => onNodeFieldChange(node.id, 'tagKey', e.value)}
+            styles={{
+              control: (baseStyles, state) => ({
+                ...baseStyles,
+                display: 'flex',
+                width: '10em',
+              }),
+            }}
+          />
+          <AsyncCreatableSelect
+            cacheOptions
+            defaultOptions
             value={{value: node.tagValue, label: node.tagValue}}
             loadOptions={callbackOptions}
             onChange={(e: any) => onNodeFieldChange(node.id, 'tagValue', e.value)}
@@ -113,6 +127,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
               control: (baseStyles, state) => ({
                 ...baseStyles,
                 display: 'flex',
+                width: '15em',
               }),
             }}
           />
@@ -129,6 +144,7 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
               borderStyle: 'solid',
               borderWidth: '1px',
               boxSizing: 'border-box',
+              width: '6em',
             }}
             value={node.value}
             onChange={(e) => onNodeFieldChange(node.id, 'value', e.target.value)}

--- a/tree.tsx
+++ b/tree.tsx
@@ -15,9 +15,9 @@ const logicalOperatorOptions: readonly Option[] = [
 ];
 
 const arthimeticOperatorOptions: readonly Option[] = [
-  { value: 'equals', label: 'equals', },
-  { value: 'greaterThan', label: 'greaterThan', },
-  { value: 'lessThan', label: 'lessThan', },
+  { value: 'equals', label: '=', },
+  { value: 'greaterThan', label: '>', },
+  { value: 'lessThan', label: '<', },
 ];
 
 const debounce = (func, delay) => {
@@ -166,7 +166,10 @@ const Tree = ({ data, onNodeFieldChange, onRemoveNode, onAddValueNode, onAddCond
             }}
           />
           <Select
-            value={{value: node.operator, label: node.operator}}
+            value={{
+              value: node.operator,
+              label: arthimeticOperatorOptions.filter(x => x.value === node.operator)[0].label
+            }}
             options={arthimeticOperatorOptions}
             onChange={(e) => onNodeFieldChange(node.id, 'operator', e.value)}
           />


### PR DESCRIPTION
The initial implementation of OSM tags in the preference tree assumed all nodes would use the `name` tag key, and thus the user input was always the tag value. This proved to be insufficient due to the wide variety of tag combinations. This PR adds the tag key as an input, as well as reworking the search operations to better support both parts of the tags.